### PR TITLE
fix(websocket): reject unsupported protocol frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,24 @@ Transport-aware events powering ergonomic RPC and streaming flows.
 > [!WARNING]
 > Eventa forwards whatever payload you emit. Validate data at the edges before sending it to untrusted peers.
 
+## Supported Transports
+
+All adapters carry the same Eventa event, invoke, stream, and cancellation protocol unless noted otherwise in their documentation.
+
+| Transport / runtime | Package export | Typical peers |
+| --- | --- | --- |
+| Electron IPC | `@moeru/eventa/adapters/electron/main`, `@moeru/eventa/adapters/electron/renderer` | Main process and renderer |
+| Tauri events | `@moeru/eventa/adapters/tauri` | JavaScript webviews |
+| DOM `EventTarget` | `@moeru/eventa/adapters/event-target` | Browser or custom event targets |
+| Node.js `EventEmitter` | `@moeru/eventa/adapters/event-emitter` | Node.js processes and libraries |
+| `window.postMessage` | `@moeru/eventa/adapters/window-message` | Windows, iframes, and popups |
+| Web Workers | `@moeru/eventa/adapters/webworkers`, `@moeru/eventa/adapters/webworkers/worker` | Browser main thread and worker |
+| Node.js Worker Threads | `@moeru/eventa/adapters/worker-threads`, `@moeru/eventa/adapters/worker-threads/worker` | Node.js main thread and worker |
+| `BroadcastChannel` | `@moeru/eventa/adapters/broadcast-channel` | Same-origin browser contexts |
+| Native WebSocket | `@moeru/eventa/adapters/websocket/native` | Browser or runtime WebSocket client |
+| H3 WebSocket | `@moeru/eventa/adapters/websocket/h3` | H3 WebSocket server |
+| Hono WebSocket | `@moeru/eventa/adapters/websocket/hono` | Hono WebSocket server |
+
 ## Installation
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -471,12 +471,24 @@ Eventa comes with various adapters for common use scenarios across browsers and 
       const chatEvents = defineInvokeEventa<{ message: string }, { text: string }>('chat:send')
       export const sendChat = defineInvoke(wsCtx, chatEvents)
       ```
-  2. Listen for connection lifecycle events to update UI state or retry logic:
+  2. Listen for connection lifecycle events to update UI state or retry logic.
+     Eventa closes an incompatible connection with code `4002` after its first
+     invalid frame, so the reconnect owner should stop retrying and prompt the
+     user to upgrade:
      ```ts
+     import { isUnsupportedProtocolClose } from '@moeru/eventa/adapters/websocket'
      import { wsConnectedEvent, wsDisconnectedEvent } from '@moeru/eventa/adapters/websocket/native'
 
      wsCtx.on(wsConnectedEvent, () => console.log('connected'))
-     wsCtx.on(wsDisconnectedEvent, () => console.log('disconnected'))
+     wsCtx.on(wsDisconnectedEvent, (event) => {
+       if (event.body && isUnsupportedProtocolClose(event.body.code)) {
+         stopReconnect()
+         showUpgradePrompt()
+         return
+       }
+
+       console.log('disconnected')
+     })
      ```
   3. Pair the client with either the H3 global or peer adapter on the server for a full RPC channel (`src/adapters/websocket/h3/*.test.ts`).
 

--- a/src/adapters/websocket/h3/global.test.ts
+++ b/src/adapters/websocket/h3/global.test.ts
@@ -1,4 +1,4 @@
-import type { Hooks, Message } from 'crossws'
+import type { Hooks, Message, Peer } from 'crossws'
 
 import type { Eventa } from '../../../eventa'
 
@@ -8,9 +8,46 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { defineEventa } from '../../../eventa'
 import { createUntil, randomBetween } from '../../../utils'
+import { WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE, WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON } from '../protocol'
 import { createGlobalContext, wsConnectedEvent, wsDisconnectedEvent, wsErrorEvent } from './global'
 
 describe('h3 websocket adapter', { timeout: 2000 }, async () => {
+  it('does not broadcast one peer protocol error to healthy peers', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
+    const ping = defineEventa<{ msg: string }>('test:h3:healthy-peer')
+    const { websocketHandlers, context } = createGlobalContext()
+    const unsupportedPeer = {
+      close: vi.fn(),
+      id: 'unsupported-peer',
+      send: vi.fn(),
+    } as unknown as Peer
+    const healthyPeer = {
+      close: vi.fn(),
+      id: 'healthy-peer',
+      send: vi.fn(),
+    } as unknown as Peer
+    const legacyMessage = {
+      text: () => '{"type":"legacy"}',
+    } as Message
+
+    websocketHandlers.open(unsupportedPeer)
+    websocketHandlers.open(healthyPeer)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    vi.mocked(unsupportedPeer.send).mockClear()
+    vi.mocked(healthyPeer.send).mockClear()
+
+    websocketHandlers.message(unsupportedPeer, legacyMessage)
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(healthyPeer.send).not.toHaveBeenCalled()
+
+    await context.emit(ping, { msg: 'still-connected' })
+
+    expect(healthyPeer.send).toHaveBeenCalledOnce()
+    expect(JSON.parse(vi.mocked(healthyPeer.send).mock.calls[0][0] as string).eventa.id).toBe(ping.id)
+    consoleError.mockRestore()
+  })
+
   it('should create a h3 ws adapter and handle events with native', async (testCtx) => {
     const port = randomBetween(40000, 50000)
     const { websocketHandlers, context: ctx } = createGlobalContext()
@@ -192,5 +229,39 @@ describe('h3 websocket adapter', { timeout: 2000 }, async () => {
     expect(disconnectData.id).toBe(wsDisconnectedEvent.id)
     expect(disconnectData.body).toBeTypeOf('object')
     expect(disconnectData.body?.id).toBe(connectData.body?.id)
+  })
+
+  it('closes a peer that sends an unsupported protocol frame', async (testCtx) => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
+    testCtx.onTestFinished(() => consoleError.mockRestore())
+    const port = randomBetween(40000, 50000)
+    const { websocketHandlers } = createGlobalContext()
+    const app = new H3()
+    app.get('/ws', defineWebSocketHandler(websocketHandlers))
+
+    const server = serve(app, {
+      port,
+      plugins: [ws({
+        resolve: async (req) => {
+          const response = (await app.fetch(req)) as Response & { crossws: Partial<Hooks> }
+          return response.crossws
+        },
+      })],
+    })
+    testCtx.onTestFinished(() => server.close())
+
+    const opened = createUntil<void>()
+    const closed = createUntil<CloseEvent>()
+    const wsConn = new WebSocket(`ws://localhost:${port}/ws`)
+    wsConn.onopen = () => opened.handler()
+    wsConn.onclose = event => closed.handler(event)
+    await opened.promise
+
+    wsConn.send('{"type":"legacy"}')
+    const closeEvent = await closed.promise
+
+    expect(closeEvent.code).toBe(WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE)
+    expect(closeEvent.reason).toBe(WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON)
+    expect(consoleError).toHaveBeenCalledOnce()
   })
 })

--- a/src/adapters/websocket/h3/global.ts
+++ b/src/adapters/websocket/h3/global.ts
@@ -1,14 +1,17 @@
 import type { Hooks, Message, Peer, WSError } from 'crossws'
 
 import type { CreateContextOptions, EventContext } from '../../../context'
+import type { WebSocketProtocolGuard } from '../protocol'
 
 import { createContext as createBaseContext } from '../../../context'
-import { and, defineEventa, EventaFlowDirection, matchBy } from '../../../eventa'
+import { and, defineEventa, defineInboundEventa, EventaFlowDirection, matchBy } from '../../../eventa'
 import { createOutboundInner, restoreInner } from '../../internal'
+import { createWebSocketProtocolGuard } from '../protocol'
 
 export const wsConnectedEvent = defineEventa<{ id: string }>('eventa:adapters:websocket-global:connected')
 export const wsDisconnectedEvent = defineEventa<{ id: string }>('eventa:adapters:websocket-global:disconnected')
 export const wsErrorEvent = defineEventa<{ error: unknown }>('eventa:adapters:websocket-global:error')
+const inboundWsErrorEvent = defineInboundEventa<{ error: unknown }>(wsErrorEvent.id)
 
 /** Creates one Eventa Context shared by all connected H3 WebSocket peers. */
 export interface H3GlobalAdapterOptions {
@@ -23,6 +26,7 @@ export function createGlobalContext(options?: H3GlobalAdapterOptions): {
   interface EmitOptions { raw: { error?: WSError, message?: Message } }
   const ctx = createBaseContext<undefined, EmitOptions>(options?.context)
   const peers = new Set<Peer>()
+  const protocolGuards = new WeakMap<Peer, WebSocketProtocolGuard<Message>>()
   ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -41,24 +45,38 @@ export function createGlobalContext(options?: H3GlobalAdapterOptions): {
     websocketHandlers: {
       open(peer) {
         peers.add(peer)
+        protocolGuards.set(peer, createWebSocketProtocolGuard<Message>({
+          close: (code, reason) => peer.close(code, reason),
+          onRejected(error, message) {
+            peers.delete(peer)
+            // This transport error belongs to the local server context. Marking
+            // it inbound keeps the global outbound bridge from broadcasting one
+            // incompatible peer's failure to every healthy peer.
+            void ctx.emit(inboundWsErrorEvent, { error }, { raw: { message } }).catch(emitError => console.error('Failed to emit WebSocket parse error:', emitError))
+          },
+        }))
         void ctx.emit(wsConnectedEvent, { id: peer.id }, { raw: {} }).catch(emitError => console.error('Failed to emit WebSocket open event:', emitError))
       },
       close(peer) {
         peers.delete(peer)
+        protocolGuards.delete(peer)
         void ctx.emit(wsDisconnectedEvent, { id: peer.id }, { raw: {} }).catch(emitError => console.error('Failed to emit WebSocket close event:', emitError))
       },
       error(_, error) {
         console.error('WebSocket error:', error)
         void ctx.emit(wsErrorEvent, { error }, { raw: { error } }).catch(emitError => console.error('Failed to emit WebSocket error:', emitError))
       },
-      message(_, message) {
+      message(peer, message) {
+        const protocolGuard = protocolGuards.get(peer)
+        if (!protocolGuard || protocolGuard.rejected) {
+          return
+        }
         try {
           const inner = restoreInner(JSON.parse(message.text()))
           void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message } }).catch(emitError => console.error('Failed to emit WebSocket message:', emitError))
         }
         catch (error) {
-          console.error('Failed to parse WebSocket message:', error)
-          void ctx.emit(wsErrorEvent, { error }, { raw: { message } }).catch(emitError => console.error('Failed to emit WebSocket parse error:', emitError))
+          protocolGuard.reject(error, message)
         }
       },
     },

--- a/src/adapters/websocket/h3/peer.test.ts
+++ b/src/adapters/websocket/h3/peer.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { defineEventa, defineInvoke, defineInvokeEventa, defineInvokeHandler } from '../../../'
 import { createUntil, randomBetween } from '../../../utils'
 import { createContext } from '../native'
+import { WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE, WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON } from '../protocol'
 import { createPeerHooks } from './peer'
 
 describe('h3 websocket adapter', { timeout: 2000 }, async () => {
@@ -209,5 +210,39 @@ describe('h3 websocket adapter', { timeout: 2000 }, async () => {
     wsConn.close()
 
     await expect(pending).rejects.toThrowError(/peer disconnected/i)
+  })
+
+  it('closes a peer that sends an unsupported protocol frame', async (testCtx) => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
+    testCtx.onTestFinished(() => consoleError.mockRestore())
+    const port = randomBetween(40000, 50000)
+    const app = new H3()
+    const { hooks } = createPeerHooks()
+    app.get('/ws', defineWebSocketHandler(hooks))
+
+    const server = serve(app, {
+      port,
+      plugins: [ws({
+        resolve: async (req) => {
+          const response = (await app.fetch(req)) as Response & { crossws: Partial<Hooks> }
+          return response.crossws
+        },
+      })],
+    })
+    testCtx.onTestFinished(() => server.close())
+
+    const opened = createUntil<void>()
+    const closed = createUntil<CloseEvent>()
+    const wsConn = new WebSocket(`ws://localhost:${port}/ws`)
+    wsConn.onopen = () => opened.handler()
+    wsConn.onclose = event => closed.handler(event)
+    await opened.promise
+
+    wsConn.send('{"type":"legacy"}')
+    const closeEvent = await closed.promise
+
+    expect(closeEvent.code).toBe(WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE)
+    expect(closeEvent.reason).toBe(WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON)
+    expect(consoleError).toHaveBeenCalledOnce()
   })
 })

--- a/src/adapters/websocket/h3/peer.ts
+++ b/src/adapters/websocket/h3/peer.ts
@@ -5,6 +5,7 @@ import type { CreateContextOptions, EventContext } from '../../../context'
 import { createContext as createBaseContext } from '../../../context'
 import { and, defineEventa, EventaFlowDirection, matchBy } from '../../../eventa'
 import { createOutboundInner, restoreInner } from '../../internal'
+import { createWebSocketProtocolGuard } from '../protocol'
 
 export const wsConnectedEvent = defineEventa<{ id: string }>('eventa:adapters:websocket-peer:connected')
 export const wsDisconnectedEvent = defineEventa<{ id: string }>('eventa:adapters:websocket-peer:disconnected')
@@ -32,6 +33,14 @@ export function createPeerContext(peer: Peer, options?: H3PeerAdapterOptions): {
       peer.send(JSON.stringify(inner))
     }
   })
+  const protocolGuard = createWebSocketProtocolGuard<Message>({
+    close: (code, reason) => peer.close(code, reason),
+    onRejected(error, message) {
+      stopSending()
+      void ctx.emit(wsErrorEvent, { error }, { raw: { message } }).catch(emitError => console.error('Failed to emit WebSocket peer parse error:', emitError))
+      ctx.abort(new Error('eventa: invoke cancelled, unsupported websocket protocol'))
+    },
+  })
 
   return {
     hooks: {
@@ -40,14 +49,15 @@ export function createPeerContext(peer: Peer, options?: H3PeerAdapterOptions): {
         if (incomingPeer.id !== peerId) {
           return
         }
+        if (protocolGuard.rejected) {
+          return
+        }
         try {
           const inner = restoreInner(JSON.parse(message.text()))
           void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message } }).catch(emitError => console.error('Failed to emit WebSocket peer message:', emitError))
         }
         catch (error) {
-          // Per-message parse failures are recoverable and do not end the peer lifetime.
-          console.error('Failed to parse WebSocket message:', error)
-          void ctx.emit(wsErrorEvent, { error }, { raw: { message } }).catch(emitError => console.error('Failed to emit WebSocket peer parse error:', emitError))
+          protocolGuard.reject(error, message)
         }
       },
       close(incomingPeer, details) {

--- a/src/adapters/websocket/hono/global.ts
+++ b/src/adapters/websocket/hono/global.ts
@@ -1,13 +1,17 @@
 import type { WSContext, WSEvents } from 'hono/ws'
 
 import type { CreateContextOptions } from '../../../context'
-import type { HonoWsEventContext, HonoWsRawEventOptions } from './shared'
+import type { WebSocketProtocolGuard } from '../protocol'
+import type { HonoWsEventContext, HonoWsMessageEvent, HonoWsRawEventOptions } from './shared'
 
 import { createContext as createBaseContext } from '../../../context'
-import { and, EventaFlowDirection, matchBy } from '../../../eventa'
+import { and, defineInboundEventa, EventaFlowDirection, matchBy } from '../../../eventa'
 import { createOutboundInner, restoreInner } from '../../internal'
+import { createWebSocketProtocolGuard } from '../protocol'
 import { readMessageText } from './internal'
 import { wsConnectedEvent, wsDisconnectedEvent, wsErrorEvent } from './shared'
+
+const inboundWsErrorEvent = defineInboundEventa<{ error: unknown }>(wsErrorEvent.id)
 
 export interface GlobalHooksResult {
   context: HonoWsEventContext
@@ -35,6 +39,7 @@ export interface CreateGlobalHooksOptions {
 export function createGlobalHooks(options: CreateGlobalHooksOptions = {}): GlobalHooksResult {
   const context = createBaseContext<undefined, HonoWsRawEventOptions>(options.context)
   const peers = new Set<WSContext>()
+  const protocolGuards = new WeakMap<WSContext, WebSocketProtocolGuard<HonoWsMessageEvent>>()
 
   context.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
@@ -53,17 +58,36 @@ export function createGlobalHooks(options: CreateGlobalHooksOptions = {}): Globa
   const hooks: WSEvents = {
     onOpen(event, ws) {
       peers.add(ws)
+      protocolGuards.set(ws, createWebSocketProtocolGuard<HonoWsMessageEvent>({
+        close: (code, reason) => ws.close(code, reason),
+        onRejected(error, event) {
+          peers.delete(ws)
+          // This transport error belongs to the local server context. Marking
+          // it inbound keeps the global outbound bridge from broadcasting one
+          // incompatible peer's failure to every healthy peer.
+          void context.emit(inboundWsErrorEvent, { error }, { raw: { message: event } }).catch(emitError => console.error('Failed to emit Hono WebSocket parse error:', emitError))
+        },
+      }))
       void context.emit(wsConnectedEvent, undefined, { raw: { open: event } }).catch(emitError => console.error('Failed to emit Hono WebSocket open event:', emitError))
     },
 
-    onMessage(event) {
+    onMessage(event, ws) {
+      const protocolGuard = protocolGuards.get(ws)
+      if (!protocolGuard || protocolGuard.rejected) {
+        return
+      }
+
       void readMessageText(event.data)
         .then(message => restoreInner(JSON.parse(message)))
         .then(
-          inner => context.emit(inner.eventa, inner.eventa.body, { raw: { message: event } }),
+          (inner) => {
+            if (protocolGuard.rejected) {
+              return
+            }
+            return context.emit(inner.eventa, inner.eventa.body, { raw: { message: event } })
+          },
           (error) => {
-            console.error('Failed to parse WebSocket message:', error)
-            return context.emit(wsErrorEvent, { error }, { raw: { message: event } })
+            protocolGuard.reject(error, event)
           },
         )
         .catch(emitError => console.error('Failed to emit Hono WebSocket message:', emitError))
@@ -71,6 +95,7 @@ export function createGlobalHooks(options: CreateGlobalHooksOptions = {}): Globa
 
     onClose(event, ws) {
       peers.delete(ws)
+      protocolGuards.delete(ws)
       void context.emit(wsDisconnectedEvent, undefined, { raw: { close: event } }).catch(emitError => console.error('Failed to emit Hono WebSocket close event:', emitError))
     },
 

--- a/src/adapters/websocket/hono/index.test.ts
+++ b/src/adapters/websocket/hono/index.test.ts
@@ -5,6 +5,7 @@ import type { HonoWsInvocableEventContext } from '.'
 import { describe, expect, it, vi } from 'vitest'
 
 import { createGlobalHooks, createPeerHooks, wsConnectedEvent, wsDisconnectedEvent } from '.'
+import { WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE, WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON } from '..'
 import { defineEventa, defineInvoke, defineInvokeEventa, defineInvokeHandler } from '../../..'
 
 function createMockWSContext(): WSContext & { sentMessages: string[] } {
@@ -194,5 +195,57 @@ describe('hono websocket adapter', () => {
 
     expect(handler).toHaveBeenCalledOnce()
     expect(handler.mock.calls[0][0].body).toEqual({ msg: 'hello' })
+  })
+
+  it('closes a peer once when it sends unsupported protocol frames', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
+    const { hooks } = createPeerHooks()
+    const ws = createMockWSContext()
+
+    hooks.onOpen?.(new Event('open'), ws)
+    hooks.onMessage?.(createMessageEvent('{"type":"legacy"}'), ws)
+    hooks.onMessage?.(createMessageEvent('{"type":"legacy-again"}'), ws)
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(ws.close).toHaveBeenCalledOnce()
+    expect(ws.close).toHaveBeenCalledWith(
+      WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE,
+      WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON,
+    )
+    expect(consoleError).toHaveBeenCalledOnce()
+    expect(consoleError).toHaveBeenCalledWith(
+      'Failed to parse WebSocket message:',
+      expect.any(TypeError),
+    )
+    consoleError.mockRestore()
+  })
+
+  it('isolates an unsupported global peer without closing healthy peers', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
+    const ping = defineEventa<{ msg: string }>('test:hono:healthy-peer')
+    const { context, hooks } = createGlobalHooks()
+    const unsupportedPeer = createMockWSContext()
+    const healthyPeer = createMockWSContext()
+
+    hooks.onOpen?.(new Event('open'), unsupportedPeer)
+    hooks.onOpen?.(new Event('open'), healthyPeer)
+    unsupportedPeer.sentMessages.length = 0
+    healthyPeer.sentMessages.length = 0
+
+    hooks.onMessage?.(createMessageEvent('{"type":"legacy"}'), unsupportedPeer)
+    hooks.onMessage?.(createMessageEvent('{"type":"legacy-again"}'), unsupportedPeer)
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(healthyPeer.sentMessages).toHaveLength(0)
+
+    context.emit(ping, { msg: 'still-connected' })
+
+    expect(unsupportedPeer.close).toHaveBeenCalledOnce()
+    expect(unsupportedPeer.sentMessages).toHaveLength(0)
+    expect(healthyPeer.close).not.toHaveBeenCalled()
+    expect(healthyPeer.sentMessages).toHaveLength(1)
+    expect(JSON.parse(healthyPeer.sentMessages[0]).eventa.id).toBe(ping.id)
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
   })
 })

--- a/src/adapters/websocket/hono/peer.ts
+++ b/src/adapters/websocket/hono/peer.ts
@@ -1,11 +1,13 @@
 import type { WSEvents } from 'hono/ws'
 
 import type { CreateContextOptions } from '../../../context'
-import type { HonoWsInvocableEventContext, HonoWsRawEventOptions } from './shared'
+import type { WebSocketProtocolGuard } from '../protocol'
+import type { HonoWsInvocableEventContext, HonoWsMessageEvent, HonoWsRawEventOptions } from './shared'
 
 import { createContext as createBaseContext } from '../../../context'
 import { and, EventaFlowDirection, matchBy } from '../../../eventa'
 import { createOutboundInner, restoreInner } from '../../internal'
+import { createWebSocketProtocolGuard } from '../protocol'
 import { readMessageText } from './internal'
 import { wsConnectedEvent, wsDisconnectedEvent, wsErrorEvent } from './shared'
 
@@ -35,6 +37,7 @@ export interface PeerHooksResult {
 export function createPeerHooks(options: CreatePeerHooksOptions = {}): PeerHooksResult {
   let context: HonoWsInvocableEventContext | undefined
   let stopSending: (() => void) | undefined
+  let protocolGuard: WebSocketProtocolGuard<HonoWsMessageEvent> | undefined
 
   const hooks: WSEvents = {
     onOpen(event, ws) {
@@ -50,24 +53,37 @@ export function createPeerHooks(options: CreatePeerHooksOptions = {}): PeerHooks
           ws.send(JSON.stringify(inner))
         }
       })
+      protocolGuard = createWebSocketProtocolGuard<HonoWsMessageEvent>({
+        close: (code, reason) => ws.close(code, reason),
+        onRejected(error, event) {
+          stopSending?.()
+          void ctx.emit(wsErrorEvent, { error }, { raw: { message: event } }).catch(emitError => console.error('Failed to emit Hono WebSocket parse error:', emitError))
+          ctx.abort(new Error('eventa: invoke cancelled, unsupported websocket protocol'))
+        },
+      })
 
       void ctx.emit(wsConnectedEvent, undefined, { raw: { open: event } }).catch(emitError => console.error('Failed to emit Hono WebSocket open event:', emitError))
       options.onContext?.(ctx)
     },
 
     onMessage(event) {
-      if (!context) {
+      if (!context || !protocolGuard || protocolGuard.rejected) {
         return
       }
       const currentContext = context
+      const currentProtocolGuard = protocolGuard
 
       void readMessageText(event.data)
         .then(message => restoreInner(JSON.parse(message)))
         .then(
-          inner => currentContext.emit(inner.eventa, inner.eventa.body, { raw: { message: event } }),
+          (inner) => {
+            if (currentProtocolGuard.rejected) {
+              return
+            }
+            return currentContext.emit(inner.eventa, inner.eventa.body, { raw: { message: event } })
+          },
           (error) => {
-            console.error('Failed to parse WebSocket message:', error)
-            return currentContext.emit(wsErrorEvent, { error }, { raw: { message: event } })
+            currentProtocolGuard.reject(error, event)
           },
         )
         .catch(emitError => console.error('Failed to emit Hono WebSocket message:', emitError))
@@ -83,6 +99,7 @@ export function createPeerHooks(options: CreatePeerHooksOptions = {}): PeerHooks
       void context.emit(wsDisconnectedEvent, undefined, { raw: { close: event } }).catch(emitError => console.error('Failed to emit Hono WebSocket close event:', emitError))
       context = undefined
       stopSending = undefined
+      protocolGuard = undefined
     },
 
     onError(event) {

--- a/src/adapters/websocket/index.ts
+++ b/src/adapters/websocket/index.ts
@@ -1,0 +1,5 @@
+export {
+  isUnsupportedProtocolClose,
+  WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE,
+  WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON,
+} from './protocol'

--- a/src/adapters/websocket/native/index.test.ts
+++ b/src/adapters/websocket/native/index.test.ts
@@ -7,12 +7,59 @@ import { defineWebSocketHandler, H3, serve } from 'h3'
 import { describe, expect, it, vi } from 'vitest'
 
 import { createContext, wsConnectedEvent, wsDisconnectedEvent, wsErrorEvent } from '.'
+import { isUnsupportedProtocolClose, WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE, WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON } from '..'
 import { defineEventa } from '../../../eventa'
 import { defineInvoke } from '../../../invoke'
 import { defineInvokeEventa } from '../../../invoke-shared'
 import { createUntil, randomBetween } from '../../../utils'
 
 describe('browser websocket adapter', () => {
+  it('closes once and aborts the context after an unsupported protocol frame', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
+    const close = vi.fn()
+    const wsConn = {
+      close,
+      send: vi.fn(),
+      url: 'ws://eventa.test',
+    } as unknown as WebSocket
+    const { context } = createContext(wsConn)
+
+    wsConn.onmessage?.({ data: '{"type":"legacy"}' } as MessageEvent)
+    wsConn.onmessage?.({ data: '{"type":"legacy-again"}' } as MessageEvent)
+
+    expect(close).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledWith(
+      WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE,
+      WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON,
+    )
+    expect(context.signal.aborted).toBe(true)
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
+  })
+
+  it('exposes close details so reconnect owners can stop on protocol mismatch', () => {
+    const wsConn = {
+      send: vi.fn(),
+      url: 'ws://eventa.test',
+    } as unknown as WebSocket
+    const { context } = createContext(wsConn)
+    const onDisconnect = vi.fn()
+    context.on(wsDisconnectedEvent, onDisconnect)
+
+    wsConn.onclose?.({
+      code: WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE,
+      reason: WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON,
+    } as CloseEvent)
+
+    expect(onDisconnect).toHaveBeenCalledOnce()
+    expect(onDisconnect.mock.calls[0][0].body).toEqual({
+      code: WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE,
+      reason: WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON,
+      url: 'ws://eventa.test',
+    })
+    expect(isUnsupportedProtocolClose(onDisconnect.mock.calls[0][0].body.code)).toBe(true)
+  })
+
   it('stops sending before publishing a close event', () => {
     const send = vi.fn()
     const wsConn = {

--- a/src/adapters/websocket/native/index.ts
+++ b/src/adapters/websocket/native/index.ts
@@ -3,10 +3,21 @@ import type { CreateContextOptions } from '../../../context'
 import { createContext as createBaseContext } from '../../../context'
 import { and, defineEventa, EventaFlowDirection, matchBy } from '../../../eventa'
 import { createOutboundInner, restoreInner } from '../../internal'
+import { createWebSocketProtocolGuard } from '../protocol'
 
 export const wsConnectedEvent = defineEventa<{ url: string }>()
-export const wsDisconnectedEvent = defineEventa<{ url: string }>()
+export const wsDisconnectedEvent = defineEventa<NativeWebSocketDisconnect>()
 export const wsErrorEvent = defineEventa<{ error: unknown }>()
+
+/** Close metadata exposed to lifecycle listeners and reconnect owners. */
+export interface NativeWebSocketDisconnect {
+  /** WebSocket close code, including Eventa's private-use protocol codes. */
+  code: number
+  /** WebSocket close reason supplied by the peer. */
+  reason: string
+  /** URL owned by the wrapped WebSocket. */
+  url: string
+}
 
 /** Creates an Eventa Context backed by a native WebSocket. */
 export interface NativeWebSocketAdapterOptions {
@@ -30,16 +41,26 @@ export function createContext(wsConn: WebSocket, options?: NativeWebSocketAdapte
       wsConn.send(JSON.stringify(inner))
     }
   })
+  const protocolGuard = createWebSocketProtocolGuard<MessageEvent>({
+    close: (code, reason) => wsConn.close(code, reason),
+    onRejected(error, event) {
+      stopSending()
+      void ctx.emit(wsErrorEvent, { error }, { raw: { message: event } }).catch(emitError => console.error('Failed to emit WebSocket parse error:', emitError))
+      ctx.abort(new Error('eventa: invoke cancelled, unsupported websocket protocol'))
+    },
+  })
 
   wsConn.onmessage = (event) => {
+    if (protocolGuard.rejected) {
+      return
+    }
+
     try {
       const inner = restoreInner(JSON.parse(String(event.data)))
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message: event } }).catch(emitError => console.error('Failed to emit WebSocket message:', emitError))
     }
     catch (error) {
-      // A malformed frame is recoverable; keep the socket lifetime alive.
-      console.error('Failed to parse WebSocket message:', error)
-      void ctx.emit(wsErrorEvent, { error }, { raw: { message: event } }).catch(emitError => console.error('Failed to emit WebSocket parse error:', emitError))
+      protocolGuard.reject(error, event)
     }
   }
   wsConn.onopen = event => void ctx.emit(wsConnectedEvent, { url: wsConn.url }, { raw: { open: event } }).catch(emitError => console.error('Failed to emit WebSocket open event:', emitError))
@@ -52,7 +73,11 @@ export function createContext(wsConn: WebSocket, options?: NativeWebSocketAdapte
   wsConn.onclose = (close) => {
     stopSending()
     ctx.abort(new Error(`eventa: invoke cancelled, websocket disconnected (${wsConn.url})`))
-    void ctx.emit(wsDisconnectedEvent, { url: wsConn.url }, { raw: { close } }).catch(emitError => console.error('Failed to emit WebSocket close event:', emitError))
+    void ctx.emit(wsDisconnectedEvent, {
+      code: close.code || 0,
+      reason: close.reason || '',
+      url: wsConn.url,
+    }, { raw: { close } }).catch(emitError => console.error('Failed to emit WebSocket close event:', emitError))
   }
 
   return { context: ctx }

--- a/src/adapters/websocket/protocol.ts
+++ b/src/adapters/websocket/protocol.ts
@@ -1,0 +1,55 @@
+/** Application close code used when a peer speaks an unsupported Eventa wire protocol. */
+export const WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE = 4002
+
+/** Stable close reason paired with {@link WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE}. */
+export const WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON = 'Unsupported Protocol'
+
+/** Returns whether a WebSocket close code identifies an Eventa protocol mismatch. */
+export function isUnsupportedProtocolClose(code: number): boolean {
+  return code === WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE
+}
+
+export interface WebSocketProtocolGuard<TDetails> {
+  /** Whether this connection has already rejected an incompatible frame. */
+  readonly rejected: boolean
+  /** Rejects the first incompatible frame and ignores subsequent frames. */
+  reject: (error: unknown, details: TDetails) => boolean
+}
+
+/**
+ * Owns the terminal protocol-error transition for one WebSocket connection.
+ * The first invalid frame is reported and closes the connection; later frames
+ * are ignored so an incompatible peer cannot create an error storm.
+ */
+export function createWebSocketProtocolGuard<TDetails>(options: {
+  close: (code: number, reason: string) => void
+  onRejected: (error: unknown, details: TDetails) => void
+}): WebSocketProtocolGuard<TDetails> {
+  let rejected = false
+
+  return {
+    get rejected() {
+      return rejected
+    },
+    reject(error, details) {
+      if (rejected) {
+        return false
+      }
+
+      rejected = true
+      console.error('Failed to parse WebSocket message:', error)
+
+      try {
+        options.onRejected(error, details)
+      }
+      finally {
+        options.close(
+          WS_UNSUPPORTED_PROTOCOL_CLOSE_CODE,
+          WS_UNSUPPORTED_PROTOCOL_CLOSE_REASON,
+        )
+      }
+
+      return true
+    },
+  }
+}


### PR DESCRIPTION
## Summary

- close incompatible WebSocket peers with `4002 Unsupported Protocol` after the first invalid Eventa frame
- share the once-per-connection guard across native, Hono peer/global, and H3 peer/global adapters
- expose close metadata and `isUnsupportedProtocolClose()` so reconnect owners can stop retrying and prompt upgrades
- keep global adapter protocol errors local instead of broadcasting them to healthy peers

## Root cause

Eventa beta.14 switched the wire format to `EventaInner`, while older clients continued sending the previous frame shape. The adapters treated `Invalid EventaInner` as recoverable and logged every frame, allowing reconnecting legacy clients to create a sustained error storm.

## User impact

An incompatible connection is now terminated deterministically instead of remaining alive and dropping every message. Healthy peers remain connected and do not receive another peer’s protocol error. Client applications can identify close code `4002` and stop automatic reconnect loops until the user upgrades.

## Validation

- `pnpm test:run`, 26 files and 191 tests passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `git diff --check`

The build still reports the existing non-fatal unused dependency hints for `h3` and `web-worker`, then completes successfully.