### PR TITLE
fix(adapters): limit repeated protocol error logs

### DIFF
--- a/docs/adr/0001-adapter-protocol-error-policy.md
+++ b/docs/adr/0001-adapter-protocol-error-policy.md
@@ -1,0 +1,37 @@
+# ADR-0001: Handle Invalid Adapter Frames by Transport Ownership
+
+**Status**: Accepted
+**Date**: 2026-08-19
+
+## Context
+
+Eventa beta.14 introduced the `EventaInner` adapter envelope. A beta.13 peer can
+send the older `id`/`type`/`payload` envelope. The shared adapter boundary now
+accepts that envelope and writes both shapes for every adapter.
+
+An actually invalid frame can still arrive repeatedly. Several adapters wrote a
+console error for every rejected frame. A reconnecting WebSocket peer caused an
+error storm in production.
+
+## Decision
+
+The adapter boundary accepts supported legacy envelopes before it classifies a
+frame as invalid.
+
+WebSocket adapters own one peer connection. They report the first invalid frame,
+abort that peer context, and close the peer with code `4002`.
+
+Other adapters do not always own an isolatable peer. They keep the transport
+usable and emit their existing adapter error event for every invalid frame. Each
+adapter context writes its diagnostic parse error to the console once.
+
+Unix sockets keep their framing policy. Invalid JSON destroys the socket. A
+valid JSON frame with an invalid Eventa envelope emits `unixSocketErrorEvent`.
+
+## Consequences
+
+Applications keep per-frame error events for monitoring and recovery. The
+Eventa library no longer floods diagnostic output from one persistent bad peer.
+
+Connection-oriented transports can end an incompatible connection. Shared or
+local transports do not terminate an unrelated sender or channel.

--- a/src/adapters/broadcast-channel/index.ts
+++ b/src/adapters/broadcast-channel/index.ts
@@ -2,6 +2,7 @@ import type { CreateContextOptions } from '../../context'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
+import { createOnceReporter } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { errorEvent } from './shared'
 
@@ -49,6 +50,7 @@ export function createContext(channel: BroadcastChannel, options?: BroadcastChan
     closeOnDispose = false,
   } = options || {}
   const cleanupRemoval: Array<{ remove: () => void }> = []
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse BroadcastChannel message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -66,7 +68,7 @@ export function createContext(channel: BroadcastChannel, options?: BroadcastChan
         void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message: event } }).catch(emitError => console.error('Failed to emit BroadcastChannel message:', emitError))
       }
       catch (error) {
-        console.error('Failed to parse BroadcastChannel message:', error)
+        reportParseError(error)
         void ctx.emit(errorEvent, { error }, { raw: { error } }).catch(emitError => console.error('Failed to emit BroadcastChannel parse error:', emitError))
       }
     }))

--- a/src/adapters/electron/main.ts
+++ b/src/adapters/electron/main.ts
@@ -4,6 +4,7 @@ import type { CreateContextOptions } from '../../context'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
+import { createOnceReporter } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { errorEvent } from './shared'
 
@@ -47,6 +48,7 @@ export function createContext(ipcMain: IpcMain, window?: BrowserWindow, options?
     onlySameWindow = false,
   } = options || {}
   const cleanupRemoval: Array<{ remove: () => void }> = []
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse IpcMain message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -96,7 +98,7 @@ export function createContext(ipcMain: IpcMain, window?: BrowserWindow, options?
         void ctx.emit(inner.eventa, inner.eventa.body, { raw: { ipcMainEvent, event } }).catch(emitError => console.error('Failed to emit IpcMain message:', emitError))
       }
       catch (error) {
-        console.error('Failed to parse IpcMain message:', error)
+        reportParseError(error)
         void ctx.emit(errorEvent, { error }, { raw: { ipcMainEvent, event } }).catch(emitError => console.error('Failed to emit IpcMain parse error:', emitError))
       }
     }))

--- a/src/adapters/electron/renderer.ts
+++ b/src/adapters/electron/renderer.ts
@@ -4,6 +4,7 @@ import type { CreateContextOptions } from '../../context'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
+import { createOnceReporter } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { errorEvent } from './shared'
 
@@ -32,6 +33,7 @@ export function createContext(ipcRenderer: IpcRenderer, options?: ElectronRender
     extraListeners = {},
   } = options || {}
   const cleanupRemoval: Array<{ remove: () => void }> = []
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse IpcRenderer message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -61,7 +63,7 @@ export function createContext(ipcRenderer: IpcRenderer, options?: ElectronRender
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { ipcRendererEvent, event } }).catch(emitError => console.error('Failed to emit IpcRenderer message:', emitError))
     }
     catch (error) {
-      console.error('Failed to parse IpcRenderer message:', error)
+      reportParseError(error)
       void ctx.emit(errorEvent, { error }, { raw: { ipcRendererEvent, event } }).catch(emitError => console.error('Failed to emit IpcRenderer parse error:', emitError))
     }
   }

--- a/src/adapters/errors.test.ts
+++ b/src/adapters/errors.test.ts
@@ -1,11 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
-import { toError } from './errors'
+import { createOnceReporter, toError } from './errors'
 
 // ErrorEvent is a browser-only global; the instanceof-ErrorEvent path is
 // covered in errors.browser.test.ts. These cases run in the node project and
 // exercise the Error, plain-object, and fallback branches.
 describe('adapters/errors', () => {
+  describe('createOnceReporter', () => {
+    it('reports only the first failure from one adapter context', () => {
+      const report = vi.fn()
+      const reportOnce = createOnceReporter(report)
+
+      reportOnce('first')
+      reportOnce('second')
+
+      expect(report).toHaveBeenCalledOnce()
+      expect(report).toHaveBeenCalledWith('first')
+    })
+  })
+
   describe('toError', () => {
     it('returns the same Error instance when given an Error', () => {
       const original = new TypeError('boom')

--- a/src/adapters/errors.ts
+++ b/src/adapters/errors.ts
@@ -34,6 +34,26 @@ interface ErrorEventLike {
 }
 
 /**
+ * Reports only the first failure observed by one adapter context.
+ *
+ * Adapters still emit their public error event for every rejected message.
+ * This helper only prevents an incompatible peer from flooding the library's
+ * diagnostic output while the transport remains usable.
+ */
+export function createOnceReporter<TArgs extends unknown[]>(report: (...args: TArgs) => void): (...args: TArgs) => void {
+  let reported = false
+
+  return (...args) => {
+    if (reported) {
+      return
+    }
+
+    reported = true
+    report(...args)
+  }
+}
+
+/**
  * Coerce whatever a transport hands us — an `Error`, a browser `ErrorEvent`, a
  * `MessageEvent`, or some host-specific object — into a real `Error`, without
  * losing the original message/stack.

--- a/src/adapters/event-emitter/index.ts
+++ b/src/adapters/event-emitter/index.ts
@@ -2,6 +2,7 @@ import type { CreateContextOptions } from '../../context'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
+import { createOnceReporter } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { errorEvent } from './shared'
 
@@ -35,6 +36,7 @@ export function createContext(eventTarget: NodeJS.EventEmitter, options?: EventE
     extraListeners = {},
   } = options || {}
   const cleanupRemoval: Array<{ remove: () => void }> = []
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse EventEmitter message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -52,7 +54,7 @@ export function createContext(eventTarget: NodeJS.EventEmitter, options?: EventE
         void ctx.emit(inner.eventa, inner.eventa.body, { raw: { event } }).catch(emitError => console.error('Failed to emit EventEmitter message:', emitError))
       }
       catch (error) {
-        console.error('Failed to parse EventEmitter message:', error)
+        reportParseError(error)
         void ctx.emit(errorEvent, { error }, { raw: { event } }).catch(emitError => console.error('Failed to emit EventEmitter parse error:', emitError))
       }
     }))

--- a/src/adapters/event-target/index.test.ts
+++ b/src/adapters/event-target/index.test.ts
@@ -114,7 +114,8 @@ describe('event target', async () => {
     expect(handler.mock.calls[2][0].body).toBe('first')
   })
 
-  it('forwards a malformed-frame error like any other Eventa', () => {
+  it('reports each malformed frame without repeating the diagnostic output', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => void 0)
     const target = new EventTarget()
     const { context } = createContext(target)
     const handler = vi.fn()
@@ -122,16 +123,20 @@ describe('event target', async () => {
     target.addEventListener('message', () => messageCount++)
     context.on(adapterErrorEvent, handler)
 
-    target.dispatchEvent(new CustomEvent('message', {
+    const malformedFrame = new CustomEvent('message', {
       detail: { id: 'legacy', payload: { id: 'event' } },
-    }))
+    })
+    target.dispatchEvent(malformedFrame)
+    target.dispatchEvent(malformedFrame)
 
-    expect(handler).toHaveBeenCalledOnce()
+    expect(handler).toHaveBeenCalledTimes(2)
     expect(handler.mock.calls[0][0].body).toMatchObject({
       kind: 'parse',
       error: expect.any(TypeError),
     })
-    expect(messageCount).toBe(2)
+    expect(messageCount).toBe(4)
+    expect(consoleError).toHaveBeenCalledOnce()
+    consoleError.mockRestore()
   })
 
   // ROOT CAUSE:

--- a/src/adapters/event-target/index.ts
+++ b/src/adapters/event-target/index.ts
@@ -2,7 +2,7 @@ import type { CreateContextOptions } from '../../context'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, EventaType, matchBy } from '../../eventa'
-import { toError } from '../errors'
+import { createOnceReporter, toError } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { adapterErrorEvent } from './shared'
 
@@ -36,6 +36,7 @@ export function createContext(eventTarget: EventTarget, options?: EventTargetAda
     extraListeners = {},
   } = options || {}
   const cleanupRemoval: Array<{ remove: () => void }> = []
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse EventTarget message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -58,7 +59,7 @@ export function createContext(eventTarget: EventTarget, options?: EventTargetAda
         void ctx.emit(inner.eventa, inner.eventa.body, { raw: { event } }).catch(emitError => console.error('Failed to emit EventTarget message:', emitError))
       }
       catch (error) {
-        console.error('Failed to parse EventTarget message:', error)
+        reportParseError(error)
         void ctx.emit(adapterErrorEvent, { kind: 'parse', error: toError(error, 'eventa: EventTarget message parse error') }, { raw: { event } }).catch(emitError => console.error('Failed to emit EventTarget parse error:', emitError))
       }
     }))

--- a/src/adapters/tauri/index.ts
+++ b/src/adapters/tauri/index.ts
@@ -9,7 +9,7 @@ import { getCurrentWebview } from '@tauri-apps/api/webview'
 import { createContext as createBaseContext } from '../../context'
 import { and, defineInboundEventa, EventaFlowDirection, matchBy } from '../../eventa'
 import { isInvokeEventa } from '../../invoke-shared'
-import { toError } from '../errors'
+import { createOnceReporter, toError } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { errorEvent } from './shared'
 
@@ -32,6 +32,7 @@ export interface TauriEmitOptions {
 
 export async function createContext(options: TauriAdapterOptions) {
   const ctx = createBaseContext<undefined, TauriEmitOptions>(options.context)
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse Tauri message:', error))
   const messageEventName = options.messageEventName ?? 'eventa-message'
   let disposePromise: Promise<void> | undefined
 
@@ -63,7 +64,7 @@ export async function createContext(options: TauriAdapterOptions) {
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { event } }).catch(emitError => console.error('Failed to emit Tauri message:', emitError))
     }
     catch (error) {
-      console.error('Failed to parse Tauri message:', error)
+      reportParseError(error)
       void ctx.emit(defineInboundEventa(errorEvent.id), { kind: 'parse', error: toError(error, 'eventa: Tauri message parse error') }, { raw: { event } }).catch(emitError => console.error('Failed to emit Tauri parse error:', emitError))
     }
   }, { target: listenTarget })

--- a/src/adapters/webworkers/index.ts
+++ b/src/adapters/webworkers/index.ts
@@ -3,7 +3,7 @@ import type { WorkerContextExtensions } from './shared'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
-import { toError } from '../errors'
+import { createOnceReporter, toError } from '../errors'
 import { createOutboundInner } from '../internal'
 import { createWorkerInnerEventa, restoreInner } from './internal'
 import { workerErrorEvent } from './shared'
@@ -22,6 +22,7 @@ export interface WebWorkerEmitOptions {
 
 export function createContext(worker: Worker, options?: WebWorkerAdapterOptions) {
   const ctx = createBaseContext<WorkerContextExtensions, WebWorkerEmitOptions>(options?.context)
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse WebWorker message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -44,7 +45,7 @@ export function createContext(worker: Worker, options?: WebWorkerAdapterOptions)
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message: event } }).catch(emitError => console.error('Failed to emit WebWorker message:', emitError))
     }
     catch (error) {
-      console.error('Failed to parse WebWorker message:', error)
+      reportParseError(error)
       void ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: webworker message parse error') }, { raw: { message: event } }).catch(emitError => console.error('Failed to emit WebWorker parse error:', emitError))
     }
   }

--- a/src/adapters/webworkers/worker/index.ts
+++ b/src/adapters/webworkers/worker/index.ts
@@ -4,7 +4,7 @@ import type { WorkerContextExtensions } from '../shared'
 
 import { createContext as createBaseContext } from '../../../context'
 import { and, EventaFlowDirection, matchBy } from '../../../eventa'
-import { toError } from '../../errors'
+import { createOnceReporter, toError } from '../../errors'
 import { createOutboundInner } from '../../internal'
 import { createWorkerInnerEventa, restoreInner } from '../internal'
 import { workerErrorEvent } from '../shared'
@@ -26,6 +26,7 @@ export interface WebWorkerSelfEmitOptions {
 export function createContext(options?: WebWorkerSelfAdapterOptions) {
   const messagePort = options?.messagePort ?? self
   const ctx = createBaseContext<WorkerContextExtensions, WebWorkerSelfEmitOptions>(options?.context) as EventContext<WorkerContextExtensions, WebWorkerSelfEmitOptions>
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse WebWorker message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -48,7 +49,7 @@ export function createContext(options?: WebWorkerSelfAdapterOptions) {
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { event } }).catch(emitError => console.error('Failed to emit WebWorker message:', emitError))
     }
     catch (error) {
-      console.error('Failed to parse WebWorker message:', error)
+      reportParseError(error)
       void ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: webworker message parse error') }, { raw: { event } }).catch(emitError => console.error('Failed to emit WebWorker parse error:', emitError))
     }
   }

--- a/src/adapters/window-message/index.ts
+++ b/src/adapters/window-message/index.ts
@@ -4,7 +4,7 @@ import type { WindowMessageEnvelope } from './shared'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
-import { toError } from '../errors'
+import { createOnceReporter, toError } from '../errors'
 import { createOutboundInner, restoreInner } from '../internal'
 import { errorEvent } from './shared'
 
@@ -53,6 +53,7 @@ export function createContext(options: WindowMessageAdapterOptions) {
   const sourceId = crypto.randomUUID()
   const { messageEvents: message = true, messageErrorEvents: messageError = true } = options
   const cleanupRemoval: Array<{ remove: () => void }> = []
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse window message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -90,7 +91,7 @@ export function createContext(options: WindowMessageAdapterOptions) {
         void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message: event } }).catch(emitError => console.error('Failed to emit window message:', emitError))
       }
       catch (error) {
-        console.error('Failed to parse window message:', error)
+        reportParseError(error)
         void ctx.emit(errorEvent, { kind: 'parse', error: toError(error, 'eventa: window message parse error') }, { raw: { error } }).catch(emitError => console.error('Failed to emit window-message parse error:', emitError))
       }
     }))

--- a/src/adapters/worker-threads/index.ts
+++ b/src/adapters/worker-threads/index.ts
@@ -5,7 +5,7 @@ import type { WorkerContextExtensions } from '../webworkers/shared'
 
 import { createContext as createBaseContext } from '../../context'
 import { and, EventaFlowDirection, matchBy } from '../../eventa'
-import { toError } from '../errors'
+import { createOnceReporter, toError } from '../errors'
 import { createOutboundInner } from '../internal'
 import { createWorkerInnerEventa, restoreInner } from '../webworkers/internal'
 import { workerErrorEvent } from '../webworkers/shared'
@@ -24,6 +24,7 @@ export interface WorkerThreadEmitOptions {
 
 export function createContext(worker: Worker, options?: WorkerThreadAdapterOptions) {
   const ctx = createBaseContext<WorkerContextExtensions, WorkerThreadEmitOptions>(options?.context)
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse Node worker message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -42,7 +43,7 @@ export function createContext(worker: Worker, options?: WorkerThreadAdapterOptio
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message } }).catch(emitError => console.error('Failed to emit Node worker message:', emitError))
     }
     catch (error) {
-      console.error('Failed to parse Node worker message:', error)
+      reportParseError(error)
       void ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: node worker message parse error') }, { raw: { message } }).catch(emitError => console.error('Failed to emit Node worker parse error:', emitError))
     }
   })

--- a/src/adapters/worker-threads/worker/index.ts
+++ b/src/adapters/worker-threads/worker/index.ts
@@ -7,7 +7,7 @@ import { parentPort } from 'node:worker_threads'
 
 import { createContext as createBaseContext } from '../../../context'
 import { and, EventaFlowDirection, matchBy } from '../../../eventa'
-import { toError } from '../../errors'
+import { createOnceReporter, toError } from '../../errors'
 import { createOutboundInner } from '../../internal'
 import { createWorkerInnerEventa, restoreInner } from '../../webworkers/internal'
 import { workerErrorEvent } from '../../webworkers/shared'
@@ -33,6 +33,7 @@ export function createContext(options?: WorkerThreadSelfAdapterOptions) {
   }
 
   const ctx = createBaseContext<WorkerContextExtensions, WorkerThreadSelfEmitOptions>(options?.context) as EventContext<WorkerContextExtensions, WorkerThreadSelfEmitOptions>
+  const reportParseError = createOnceReporter((error: unknown) => console.error('Failed to parse Node worker message:', error))
   const stopSending = ctx.on(and(
     matchBy(event => !('_flowDirection' in event) || !event._flowDirection || event._flowDirection === EventaFlowDirection.Outbound),
     matchBy('*'),
@@ -55,7 +56,7 @@ export function createContext(options?: WorkerThreadSelfAdapterOptions) {
       void ctx.emit(inner.eventa, inner.eventa.body, { raw: { message } }).catch(emitError => console.error('Failed to emit Node worker message:', emitError))
     }
     catch (error) {
-      console.error('Failed to parse Node worker message:', error)
+      reportParseError(error)
       void ctx.emit(workerErrorEvent, { kind: 'parse', error: toError(error, 'eventa: node worker message parse error') }, { raw: { message } }).catch(emitError => console.error('Failed to emit Node worker parse error:', emitError))
     }
   })


### PR DESCRIPTION
## Summary

- add ADR-0001 to define invalid-frame handling by transport ownership
- limit diagnostic parse-error output to one message per non-WebSocket adapter context
- retain each adapter's existing parse-error event for every rejected message

## Why

PR #70 closes a bad WebSocket peer because WebSocket owns that peer connection.
Other adapters can share a channel or do not own the sender. They must not close
an unrelated sender or channel. They now report the first diagnostic error only.

The shared adapter boundary continues to accept supported beta.13 envelopes.
Only malformed or unsupported frames enter this error path.

## Validation

- `pnpm exec vitest run src/adapters/errors.test.ts src/adapters/event-target/index.test.ts`
- `pnpm test:run` (27 files, 195 tests)
- `pnpm typecheck`
- `pnpm lint`
- `git diff --check`
